### PR TITLE
Optimize AR chat and Gemini image pipeline

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -24,7 +24,7 @@ export default async function handler(req, res) {
 
   try {
     console.log('[API] リクエスト受信:', req.method, req.url);
-    console.log('[API] ボディ:', req.body);
+    console.log('[API] 添付数:', Array.isArray(req.body?.attachments) ? req.body.attachments.length : 0);
     
     // 動的インポート（Vercel環境用）
     let handleFunctionCalling;
@@ -43,10 +43,12 @@ export default async function handler(req, res) {
       return;
     }
     
-    const { message, oauthToken } = req.body;
+    const { message, oauthToken, attachments } = req.body;
+    const normalizedMessage = typeof message === 'string' ? message.trim() : '';
+    const hasAttachments = Array.isArray(attachments) && attachments.length > 0;
 
-    if (!message) {
-      res.status(400).json({ error: 'メッセージが必要です' });
+    if (!normalizedMessage && !hasAttachments) {
+      res.status(400).json({ error: 'メッセージまたは画像が必要です' });
       return;
     }
 
@@ -60,12 +62,13 @@ export default async function handler(req, res) {
       return;
     }
 
-    console.log('[API] ユーザーメッセージ:', message);
+    console.log('[API] ユーザーメッセージ:', normalizedMessage || '画像のみ');
 
     const result = await handleFunctionCalling(
       process.env.GEMINI_API_KEY,
-      message,
-      oauthToken || null
+      normalizedMessage,
+      oauthToken || null,
+      attachments || []
     );
 
     console.log('[API] Gemini応答:', result);
@@ -85,4 +88,3 @@ export default async function handler(req, res) {
     });
   }
 }
-

--- a/server/index.ts
+++ b/server/index.ts
@@ -11,22 +11,25 @@ const app = express();
 const PORT = process.env.PORT || 3000;
 
 app.use(cors());
-app.use(bodyParser.json());
+app.use(bodyParser.json({ limit: '8mb' }));
 
 app.post('/api/chat', async (req: Request<{}, ChatResponse, ChatRequest>, res: Response<ChatResponse | { error: string; message?: string; emotion?: string }>) => {
   try {
-    const { message, oauthToken } = req.body;
+    const { message, oauthToken, attachments } = req.body;
+    const normalizedMessage = message?.trim() || '';
+    const hasAttachments = Array.isArray(attachments) && attachments.length > 0;
 
-    if (!message) {
-      return res.status(400).json({ error: 'メッセージが必要です' });
+    if (!normalizedMessage && !hasAttachments) {
+      return res.status(400).json({ error: 'メッセージまたは画像が必要です' });
     }
 
-    console.log('[API] ユーザーメッセージ:', message);
+    console.log('[API] ユーザーメッセージ:', normalizedMessage || '画像のみ');
 
     const result = await handleFunctionCalling(
       process.env.GEMINI_API_KEY!,
-      message,
-      oauthToken || null
+      normalizedMessage,
+      oauthToken || null,
+      attachments || []
     );
 
     console.log('[API] Gemini応答:', result);

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,7 @@
   "description": "",
   "dependencies": {
     "@ai-sdk/google": "^2.0.17",
-    "@google/genai": "^1.21.0",
+    "@google/genai": "^1.52.0",
     "@mastra/core": "^0.19.1",
     "better-sqlite3": "^12.4.1",
     "body-parser": "^2.2.0",

--- a/server/services/gemini.service.ts
+++ b/server/services/gemini.service.ts
@@ -1,6 +1,6 @@
 import { GoogleGenAI } from '@google/genai';
 import { google } from 'googleapis';
-import type { CalendarEvent, GeminiResponse } from '../types/chat.types.js';
+import type { CalendarEvent, ChatAttachment, GeminiResponse } from '../types/chat.types.js';
 import type { EmotionType } from '../types/emotion.types.js';
 
 // レスポンススキーマの定義
@@ -84,13 +84,78 @@ const CLAUDIA_CHARACTER_INSTRUCTION = `
 - 自分の役割（Cor.Inc.のAIアンバサダー）を意識して会話すること
 `;
 
-const MODEL_NAME = 'gemini-2.5-flash';
+const MODEL_NAME = process.env.GEMINI_MODEL || 'gemini-3.1-flash-lite-preview';
+
+const SUPPORTED_IMAGE_MIME_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+]);
+
+type GeminiContentPart = {
+  text?: string;
+  inlineData?: {
+    mimeType: string;
+    data: string;
+  };
+};
 
 interface CalendarExecutionResult {
   success: boolean;
   events?: CalendarEvent[];
   message?: string;
   error?: string;
+}
+
+function buildGenerationConfig(includeStructuredOutput: boolean): Record<string, unknown> {
+  const config: Record<string, unknown> = {
+    responseModalities: ['TEXT'],
+    systemInstruction: CLAUDIA_CHARACTER_INSTRUCTION,
+    temperature: 0.5,
+    topP: 0.8,
+    topK: 40,
+    maxOutputTokens: 1024,
+  };
+
+  if (includeStructuredOutput) {
+    config.responseMimeType = 'application/json';
+    config.responseSchema = responseSchema;
+  }
+
+  return config;
+}
+
+function normalizeImageAttachments(attachments: ChatAttachment[] = []): ChatAttachment[] {
+  return attachments
+    .filter((attachment) => SUPPORTED_IMAGE_MIME_TYPES.has(attachment.mimeType))
+    .filter((attachment) => attachment.data.length <= 6_000_000)
+    .slice(0, 3);
+}
+
+function buildUserContents(userPrompt: string, attachments: ChatAttachment[] = []): string | GeminiContentPart[] {
+  const imageParts = normalizeImageAttachments(attachments).map((attachment) => ({
+    inlineData: {
+      mimeType: attachment.mimeType,
+      data: attachment.data,
+    },
+  }));
+
+  if (imageParts.length === 0) {
+    return userPrompt;
+  }
+
+  return [
+    ...imageParts,
+    {
+      text: userPrompt || '添付された画像について説明してください。',
+    },
+  ];
+}
+
+function shouldTryFunctionCallingFirst(userPrompt: string): boolean {
+  return /カレンダー|予定|スケジュール|空き|空いて|会議|打ち合わせ/.test(userPrompt);
 }
 
 /**
@@ -193,50 +258,42 @@ async function execute_calendar_events(
 export async function handleFunctionCalling(
   apiKey: string,
   userPrompt: string,
-  oauthToken: string | null
+  oauthToken: string | null,
+  attachments: ChatAttachment[] = []
 ): Promise<GeminiResponse> {
   const ai = new GoogleGenAI({ apiKey });
+  const userContents = buildUserContents(userPrompt, attachments);
+  const tryFunctionCallingFirst = shouldTryFunctionCallingFirst(userPrompt);
 
   // まずStructured Outputで直接応答を試みる（Function Calling不要の場合）
-  const directResponse = await ai.models.generateContent({
-    model: MODEL_NAME,
-    contents: userPrompt,
-    config: {
-      responseModalities: ['TEXT'],
-      responseMimeType: 'application/json',
-      responseSchema: responseSchema,
-      systemInstruction: CLAUDIA_CHARACTER_INSTRUCTION,
-      temperature: 0.5,
-      topP: 0.8,
-      topK: 40,
-      maxOutputTokens: 1024,
-    }
-  });
+  if (!tryFunctionCallingFirst) {
+    const directResponse = await ai.models.generateContent({
+      model: MODEL_NAME,
+      contents: userContents,
+      config: buildGenerationConfig(true)
+    });
 
-  if (directResponse.text) {
-    try {
-      const parsedResponse = JSON.parse(directResponse.text);
-      return {
-        text: parsedResponse.message,
-        emotion: parsedResponse.emotion as EmotionType
-      };
-    } catch (parseError) {
-      // JSON解析失敗 - Function Callingが必要かもしれない
-      console.log('[Info] Structured Outputのみでは不十分、Function Calling試行');
+    if (directResponse.text) {
+      try {
+        const parsedResponse = JSON.parse(directResponse.text);
+        return {
+          text: parsedResponse.message,
+          emotion: parsedResponse.emotion as EmotionType
+        };
+      } catch (parseError) {
+        // JSON解析失敗 - Function Callingが必要かもしれない
+        console.log('[Info] Structured Outputのみでは不十分、Function Calling試行');
+      }
     }
   }
 
   // Function Calling対応（Structured OutputなしのAPIコール）
   const fcResponse = await ai.models.generateContent({
     model: MODEL_NAME,
-    contents: userPrompt,
+    contents: userContents,
     config: {
-      systemInstruction: CLAUDIA_CHARACTER_INSTRUCTION,
+      ...buildGenerationConfig(false),
       tools: [{ functionDeclarations }],
-      temperature: 0.5,
-      topP: 0.8,
-      topK: 40,
-      maxOutputTokens: 1024,
     }
   });
 
@@ -257,16 +314,7 @@ export async function handleFunctionCalling(
       const formattedResponse = await ai.models.generateContent({
         model: MODEL_NAME,
         contents: `以下のテキストをJSON形式に変換してください: ${text}`,
-        config: {
-          responseModalities: ['TEXT'],
-          responseMimeType: 'application/json',
-          responseSchema: responseSchema,
-          systemInstruction: CLAUDIA_CHARACTER_INSTRUCTION,
-          temperature: 0.5,
-          topP: 0.8,
-          topK: 40,
-          maxOutputTokens: 1024,
-        }
+        config: buildGenerationConfig(true)
       });
 
       if (formattedResponse.text) {
@@ -321,16 +369,7 @@ export async function handleFunctionCalling(
     const finalResponse = await ai.models.generateContent({
       model: MODEL_NAME,
       contents: `ユーザーの質問: ${userPrompt}\n\nカレンダー情報: ${JSON.stringify(functionResponses[0].response)}\n\n上記の情報に基づいて博多弁で応答してください。`,
-      config: {
-        responseModalities: ['TEXT'],
-        responseMimeType: 'application/json',
-        responseSchema: responseSchema,
-        systemInstruction: CLAUDIA_CHARACTER_INSTRUCTION,
-        temperature: 0.5,
-        topP: 0.8,
-        topK: 40,
-        maxOutputTokens: 1024,
-      }
+      config: buildGenerationConfig(true)
     });
 
     if (finalResponse.text) {

--- a/server/types/chat.types.ts
+++ b/server/types/chat.types.ts
@@ -13,15 +13,27 @@ export interface ChatMessage {
   content: string;
   timestamp: Date;
   emotion?: EmotionType;
+  attachments?: ChatAttachment[];
+}
+
+/**
+ * 画像添付
+ */
+export interface ChatAttachment {
+  mimeType: string;
+  data: string;
+  name?: string;
+  size?: number;
 }
 
 /**
  * チャットリクエスト
  */
 export interface ChatRequest {
-  message: string;
+  message?: string;
   oauthToken?: string;
   conversationHistory?: ChatMessage[];
+  attachments?: ChatAttachment[];
 }
 
 /**

--- a/src/components/BottomSheet.ts
+++ b/src/components/BottomSheet.ts
@@ -3,20 +3,30 @@
  * AR表示領域を最大化しながら、直感的なチャット操作を提供
  */
 
-import type { BottomSheetState, BottomSheetConfig, ChatMessage } from '../types/chat.types.js';
+import type {
+  BottomSheetState,
+  BottomSheetConfig,
+  ChatAttachment,
+  ChatMessage,
+  MessageSendPayload,
+} from '../types/chat.types.js';
 
 export class BottomSheet {
   private container: HTMLElement | null = null;
   private messagesContainer: HTMLElement | null = null;
   private inputContainer: HTMLElement | null = null;
+  private attachmentPreview: HTMLElement | null = null;
   private dragHandle: HTMLElement | null = null;
   private inputElement: HTMLInputElement | null = null;
+  private fileInputElement: HTMLInputElement | null = null;
+  private attachButton: HTMLButtonElement | null = null;
   private sendButton: HTMLButtonElement | null = null;
 
   private state: BottomSheetState = 'collapsed';
   private startY: number = 0;
   private currentY: number = 0;
   private messages: ChatMessage[] = [];
+  private pendingAttachment: ChatAttachment | null = null;
 
   private config: BottomSheetConfig = {
     collapsedHeight: 120,
@@ -26,11 +36,12 @@ export class BottomSheet {
     animationDuration: 300,
   };
 
-  private onSendMessage: ((message: string) => void) | null = null;
+  private onSendMessage: ((payload: MessageSendPayload) => void) | null = null;
 
   constructor() {
     this.createBottomSheet();
     this.attachEventListeners();
+    this.syncViewportMetrics();
   }
 
   /**
@@ -43,7 +54,16 @@ export class BottomSheet {
         <div class="messages-preview" id="messages-preview">
           <!-- メッセージがここに表示されます -->
         </div>
+        <div class="attachment-preview" id="attachment-preview" aria-live="polite"></div>
         <div class="input-container" id="input-container">
+          <input
+            type="file"
+            id="bottom-sheet-file"
+            class="bottom-sheet-file"
+            accept="image/png,image/jpeg,image/webp,image/heic,image/heif"
+            aria-label="画像を添付"
+          />
+          <button id="bottom-sheet-attach" class="bottom-sheet-attach" title="画像を添付" aria-label="画像を添付">+</button>
           <input
             type="text"
             id="bottom-sheet-input"
@@ -60,8 +80,11 @@ export class BottomSheet {
     this.container = document.getElementById('bottom-sheet');
     this.dragHandle = document.getElementById('drag-handle');
     this.messagesContainer = document.getElementById('messages-preview');
+    this.attachmentPreview = document.getElementById('attachment-preview');
     this.inputContainer = document.getElementById('input-container');
     this.inputElement = document.getElementById('bottom-sheet-input') as HTMLInputElement;
+    this.fileInputElement = document.getElementById('bottom-sheet-file') as HTMLInputElement;
+    this.attachButton = document.getElementById('bottom-sheet-attach') as HTMLButtonElement;
     this.sendButton = document.getElementById('bottom-sheet-send') as HTMLButtonElement;
 
     // 初期状態を設定
@@ -72,7 +95,7 @@ export class BottomSheet {
    * イベントリスナーを設定
    */
   private attachEventListeners(): void {
-    if (!this.dragHandle || !this.inputElement || !this.sendButton) {
+    if (!this.dragHandle || !this.inputElement || !this.fileInputElement || !this.attachButton || !this.sendButton) {
       console.error('[BottomSheet] Required elements not found');
       return;
     }
@@ -88,6 +111,10 @@ export class BottomSheet {
     // 送信ボタン
     this.sendButton.addEventListener('click', this.handleSend.bind(this));
 
+    // 画像添付
+    this.attachButton.addEventListener('click', () => this.fileInputElement?.click());
+    this.fileInputElement.addEventListener('change', this.handleFileSelection.bind(this));
+
     // Enterキーで送信
     this.inputElement.addEventListener('keypress', (e: KeyboardEvent) => {
       if (e.key === 'Enter' && !e.shiftKey) {
@@ -95,6 +122,181 @@ export class BottomSheet {
         this.handleSend();
       }
     });
+
+    this.inputElement.addEventListener('focus', () => {
+      if (this.state === 'collapsed' && this.messages.length > 0) {
+        this.peek();
+      }
+      this.syncViewportMetrics();
+    });
+
+    this.inputElement.addEventListener('blur', () => {
+      window.setTimeout(() => this.syncViewportMetrics(), 120);
+    });
+
+    window.visualViewport?.addEventListener('resize', this.syncViewportMetrics);
+    window.visualViewport?.addEventListener('scroll', this.syncViewportMetrics);
+    window.addEventListener('resize', this.syncViewportMetrics);
+  }
+
+  /**
+   * iOS Safariのキーボード表示時にAR画面をリサイズせず、入力欄だけを追従させる
+   */
+  private syncViewportMetrics = (): void => {
+    if (!this.container) return;
+
+    const viewport = window.visualViewport;
+    const keyboardOffset = viewport
+      ? Math.max(0, window.innerHeight - viewport.height - viewport.offsetTop)
+      : 0;
+
+    this.container.style.setProperty('--keyboard-offset', `${keyboardOffset}px`);
+
+    if (this.inputContainer) {
+      const inputHeight = this.inputContainer.getBoundingClientRect().height;
+      this.container.style.setProperty('--chat-input-height', `${Math.ceil(inputHeight)}px`);
+    }
+  };
+
+  /**
+   * 状態ごとのCSSクラスを更新
+   */
+  private updateStateClass(): void {
+    if (!this.container) return;
+
+    this.container.classList.remove('state-collapsed', 'state-peek', 'state-expanded');
+    this.container.classList.add(`state-${this.state}`);
+  }
+
+  /**
+   * 添付画像を端末側で圧縮し、APIへ送れるBase64に変換する
+   */
+  private async handleFileSelection(): Promise<void> {
+    const file = this.fileInputElement?.files?.[0];
+    if (!file) return;
+
+    if (!file.type.startsWith('image/')) {
+      this.showAttachmentError('画像ファイルを選択してください。');
+      this.clearFileInput();
+      return;
+    }
+
+    try {
+      this.pendingAttachment = await this.optimizeImage(file);
+      this.renderAttachmentPreview(file.name);
+    } catch (error) {
+      console.error('[BottomSheet] 画像の処理に失敗:', error);
+      this.showAttachmentError('画像の読み込みに失敗しました。');
+      this.pendingAttachment = null;
+    } finally {
+      this.clearFileInput();
+      this.syncViewportMetrics();
+    }
+  }
+
+  /**
+   * モバイル回線とVercel payload制限を考慮して画像を縮小する
+   */
+  private async optimizeImage(file: File): Promise<ChatAttachment> {
+    const dataUrl = await this.readFileAsDataURL(file);
+    let optimizedDataUrl: string;
+
+    try {
+      optimizedDataUrl = await this.resizeImage(dataUrl, 1280, 0.82);
+    } catch (error) {
+      // HEICなどCanvasでデコードできない形式は、小さい場合だけ元データを送る
+      if (file.size > 4_000_000) {
+        throw error;
+      }
+      optimizedDataUrl = dataUrl;
+    }
+
+    const [header, data] = optimizedDataUrl.split(',');
+    const mimeType = header.match(/^data:(.*);base64$/)?.[1] || 'image/jpeg';
+
+    return {
+      mimeType,
+      data,
+      name: file.name,
+      size: Math.ceil((data.length * 3) / 4),
+    };
+  }
+
+  private readFileAsDataURL(file: File): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(String(reader.result));
+      reader.onerror = () => reject(reader.error);
+      reader.readAsDataURL(file);
+    });
+  }
+
+  private resizeImage(dataUrl: string, maxSize: number, quality: number): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => {
+        const scale = Math.min(1, maxSize / Math.max(img.width, img.height));
+        const width = Math.max(1, Math.round(img.width * scale));
+        const height = Math.max(1, Math.round(img.height * scale));
+        const canvas = document.createElement('canvas');
+        canvas.width = width;
+        canvas.height = height;
+
+        const context = canvas.getContext('2d');
+        if (!context) {
+          reject(new Error('Canvas context is not available'));
+          return;
+        }
+
+        context.drawImage(img, 0, 0, width, height);
+        resolve(canvas.toDataURL('image/jpeg', quality));
+      };
+      img.onerror = () => reject(new Error('Image decode failed'));
+      img.src = dataUrl;
+    });
+  }
+
+  private renderAttachmentPreview(fileName: string): void {
+    if (!this.attachmentPreview || !this.pendingAttachment) return;
+
+    this.attachmentPreview.innerHTML = `
+      <div class="attachment-pill">
+        <span class="attachment-name">${this.escapeHtml(fileName)}</span>
+        <button class="attachment-remove" type="button" aria-label="添付画像を削除">x</button>
+      </div>
+    `;
+    this.attachmentPreview.style.display = 'block';
+    this.attachmentPreview
+      .querySelector('.attachment-remove')
+      ?.addEventListener('click', () => this.clearAttachment());
+  }
+
+  private showAttachmentError(message: string): void {
+    if (!this.attachmentPreview) return;
+
+    this.attachmentPreview.innerHTML = `<div class="attachment-error">${this.escapeHtml(message)}</div>`;
+    this.attachmentPreview.style.display = 'block';
+    window.setTimeout(() => {
+      if (!this.pendingAttachment && this.attachmentPreview) {
+        this.attachmentPreview.style.display = 'none';
+        this.attachmentPreview.innerHTML = '';
+      }
+    }, 3000);
+  }
+
+  private clearAttachment(): void {
+    this.pendingAttachment = null;
+    if (this.attachmentPreview) {
+      this.attachmentPreview.style.display = 'none';
+      this.attachmentPreview.innerHTML = '';
+    }
+    this.syncViewportMetrics();
+  }
+
+  private clearFileInput(): void {
+    if (this.fileInputElement) {
+      this.fileInputElement.value = '';
+    }
   }
 
   /**
@@ -115,13 +317,13 @@ export class BottomSheet {
     this.currentY = e.touches[0].clientY;
     const deltaY = this.startY - this.currentY;
 
-    const currentHeight = this.container.offsetHeight;
+    const currentHeight = Number(this.container.dataset.sheetHeight || this.config.collapsedHeight);
     const newHeight = Math.max(
       this.config.collapsedHeight,
       Math.min(this.config.expandedHeight, currentHeight + deltaY)
     );
 
-    this.container.style.height = `${newHeight}px`;
+    this.container.dataset.sheetHeight = `${newHeight}`;
     this.startY = this.currentY;
   }
 
@@ -131,7 +333,7 @@ export class BottomSheet {
   private onDragEnd(): void {
     if (!this.container) return;
 
-    const currentHeight = this.container.offsetHeight;
+    const currentHeight = Number(this.container.dataset.sheetHeight || this.config.collapsedHeight);
 
     // スナップポイントを決定
     if (currentHeight < this.config.peekHeight - this.config.dragThreshold) {
@@ -141,6 +343,7 @@ export class BottomSheet {
     } else {
       this.expand();
     }
+    delete this.container.dataset.sheetHeight;
   }
 
   /**
@@ -156,13 +359,13 @@ export class BottomSheet {
       this.currentY = moveEvent.clientY;
       const deltaY = this.startY - this.currentY;
 
-      const currentHeight = this.container.offsetHeight;
+      const currentHeight = Number(this.container.dataset.sheetHeight || this.config.collapsedHeight);
       const newHeight = Math.max(
         this.config.collapsedHeight,
         Math.min(this.config.expandedHeight, currentHeight + deltaY)
       );
 
-      this.container.style.height = `${newHeight}px`;
+      this.container.dataset.sheetHeight = `${newHeight}`;
       this.startY = this.currentY;
     };
 
@@ -170,6 +373,7 @@ export class BottomSheet {
       document.removeEventListener('mousemove', onMouseMove);
       document.removeEventListener('mouseup', onMouseUp);
       this.onDragEnd();
+      if (this.container) delete this.container.dataset.sheetHeight;
     };
 
     document.addEventListener('mousemove', onMouseMove);
@@ -183,8 +387,9 @@ export class BottomSheet {
     if (!this.container || !this.messagesContainer) return;
 
     this.state = 'collapsed';
-    this.container.style.height = `${this.config.collapsedHeight}px`;
+    this.updateStateClass();
     this.messagesContainer.style.display = 'none';
+    this.syncViewportMetrics();
   }
 
   /**
@@ -194,9 +399,10 @@ export class BottomSheet {
     if (!this.container || !this.messagesContainer) return;
 
     this.state = 'peek';
-    this.container.style.height = `${this.config.peekHeight}px`;
+    this.updateStateClass();
     this.messagesContainer.style.display = 'flex';
     this.displayRecentMessages(2);
+    this.syncViewportMetrics();
   }
 
   /**
@@ -206,9 +412,10 @@ export class BottomSheet {
     if (!this.container || !this.messagesContainer) return;
 
     this.state = 'expanded';
-    this.container.style.height = `${this.config.expandedHeight}px`;
+    this.updateStateClass();
     this.messagesContainer.style.display = 'flex';
     this.displayRecentMessages(10);
+    this.syncViewportMetrics();
   }
 
   /**
@@ -256,16 +463,18 @@ export class BottomSheet {
   private handleSend(): void {
     if (!this.inputElement) return;
 
-    const text = this.inputElement.value.trim();
+    const attachments = this.pendingAttachment ? [this.pendingAttachment] : undefined;
+    const text = this.inputElement.value.trim() || (attachments ? 'この画像について説明して' : '');
     if (!text) return;
 
     // ユーザーメッセージを追加
-    this.addMessage('user', text);
+    this.addMessage('user', attachments ? `${text}（画像付き）` : text);
     this.inputElement.value = '';
+    this.clearAttachment();
 
     // コールバックを実行
     if (this.onSendMessage) {
-      this.onSendMessage(text);
+      this.onSendMessage({ message: text, attachments });
     }
   }
 
@@ -313,6 +522,10 @@ export class BottomSheet {
 
     this.messagesContainer.insertAdjacentHTML('beforeend', typingHTML);
     this.messagesContainer.scrollTop = this.messagesContainer.scrollHeight;
+
+    if (this.state === 'collapsed') {
+      this.peek();
+    }
   }
 
   /**
@@ -328,7 +541,7 @@ export class BottomSheet {
   /**
    * メッセージ送信コールバックを設定
    */
-  public setSendCallback(callback: (message: string) => void): void {
+  public setSendCallback(callback: (payload: MessageSendPayload) => void): void {
     this.onSendMessage = callback;
   }
 

--- a/src/controllers/ChatController.ts
+++ b/src/controllers/ChatController.ts
@@ -3,7 +3,7 @@
  */
 
 import { BottomSheet } from '../components/BottomSheet.js';
-import type { ChatAPIResponse } from '../types/chat.types.js';
+import type { ChatAPIResponse, MessageSendPayload } from '../types/chat.types.js';
 
 export class ChatController {
   private bottomSheet: BottomSheet;
@@ -18,7 +18,7 @@ export class ChatController {
   /**
    * メッセージを送信してAPIから応答を取得
    */
-  private async sendMessage(text: string): Promise<void> {
+  private async sendMessage(payload: MessageSendPayload): Promise<void> {
     try {
       // タイピングインジケーター表示
       this.bottomSheet.showTyping();
@@ -29,7 +29,8 @@ export class ChatController {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          message: text,
+          message: payload.message,
+          attachments: payload.attachments,
         }),
       });
 

--- a/src/index.html
+++ b/src/index.html
@@ -2,14 +2,14 @@
 <html lang="ja">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>Cor.Inc AR Demo</title>
 
   <!-- A-Frame 1.7.0 -->
   <script src="https://aframe.io/releases/1.7.0/aframe.min.js"></script>
 
   <!-- AR.js (パターンマーカー用) -->
-  <script src="https://raw.githack.com/AR-js-org/AR.js/master/aframe/build/aframe-ar.js"></script>
+  <script src="https://raw.githack.com/AR-js-org/AR.js/3.4.7/aframe/build/aframe-ar.js"></script>
 
   <!-- Three.js + three-vrm + three-vrm-animation (Import Map) -->
   <!-- Phase 7: 公式パッケージへ移行 (three v0.177.0, three-vrm v3.4.2) -->
@@ -37,10 +37,20 @@
   <link rel="stylesheet" href="/src/styles/bottom-sheet.css">
 
   <style>
+    html,
     body { 
       margin: 0; 
+      width: 100%;
+      height: 100%;
+      min-height: 100dvh;
       overflow: hidden;
       background-color: #000; /* AR表示と同じ黒背景 */
+      overscroll-behavior: none;
+      touch-action: manipulation;
+    }
+    body {
+      position: fixed;
+      inset: 0;
     }
     #info {
       position: absolute;
@@ -109,6 +119,10 @@
     }
     /* A-Frame Stats（パフォーマンス監視） */
     .a-canvas {
+      position: fixed !important;
+      inset: 0 !important;
+      width: 100vw !important;
+      height: 100dvh !important;
       z-index: 0;
     }
     .rs-base {
@@ -134,7 +148,7 @@
 
   <a-scene
     embedded
-    arjs="sourceType: webcam; sourceWidth: 1280; sourceHeight: 960; displayWidth: 1280; displayHeight: 960; trackingMethod: best; patternRatio: 0.80; labelingMode: black_region; maxDetectionRate: 60; debugUIEnabled: false;"
+    arjs="sourceType: webcam; sourceWidth: 1280; sourceHeight: 960; displayWidth: 1280; displayHeight: 960; trackingMethod: best; detectionMode: mono; patternRatio: 0.80; labelingMode: black_region; maxDetectionRate: 60; imageSmoothingEnabled: true; debugUIEnabled: false;"
     vr-mode-ui="enabled: false"
     id="ar-scene"
   >
@@ -145,12 +159,13 @@
       type="pattern" 
       url="./assets/markers/penguin-marker.patt" 
       id="marker"
+      emitevents="true"
       size="1"
       smooth="true"
-      smoothCount="5"
-      smoothTolerance="0.02"
-      smoothThreshold="2"
-      minConfidence="0.5"
+      smoothCount="8"
+      smoothTolerance="0.015"
+      smoothThreshold="3"
+      minConfidence="0.45"
     >
       <!-- ライト（モバイルGPU負荷低減のため最小限に） -->
       <a-light type="ambient" intensity="1.0"></a-light>
@@ -213,43 +228,6 @@
         debugLog('[Mobile] 画面サイズ:', window.innerWidth, 'x', window.innerHeight);
         debugLog('[Mobile] デバイスピクセル比:', window.devicePixelRatio);
         
-        // カメラ解像度の確認とフォールバック警告
-        navigator.mediaDevices.getUserMedia({ 
-          video: { 
-            width: { ideal: 1280, min: 640 }, 
-            height: { ideal: 960, min: 480 } 
-          } 
-        })
-          .then((stream) => {
-            const track = stream.getVideoTracks()[0];
-            const settings = track.getSettings();
-            debugLog('[Camera] 実際の解像度:', settings.width, 'x', settings.height);
-            debugLog('[Camera] フレームレート:', settings.frameRate);
-            
-            // 解像度フォールバック警告（ユーザーに重要な情報はUI表示）
-            if (settings.width < 1280 || settings.height < 960) {
-              debugWarn('[Camera] ⚠️ 高解像度が利用不可、フォールバック動作中');
-              debugWarn('[Camera] 検出距離が短くなる可能性があります');
-              // ユーザー向けは簡潔に
-              document.querySelector('#status').textContent = '⚠️ 解像度制限';
-            }
-            
-            track.stop();
-          })
-          .catch((err) => {
-            errorLog('[Camera] カメラアクセス失敗:', err);
-            document.querySelector('#status').textContent = '❌ カメラエラー';
-          });
-        
-        // フルスクリーン要求（タップ時）
-        document.addEventListener('click', () => {
-          if (!document.fullscreenElement) {
-            document.documentElement.requestFullscreen().catch((err) => {
-              debugLog('[Mobile] フルスクリーン要求失敗:', err);
-            });
-          }
-        }, { once: true });
-
         // 向き変更イベント監視（縦向きデフォルト、強制なし）
         window.addEventListener('orientationchange', () => {
           const isLandscape = screen.orientation && screen.orientation.type.includes('landscape');
@@ -267,9 +245,9 @@
         
         // minConfidenceを初期値に戻す（検出成功時）
         const currentConfidence = marker.getAttribute('minConfidence');
-        if (currentConfidence < 0.5) {
-          marker.setAttribute('minConfidence', 0.5);
-          debugLog('[Marker] 感度リセット: minConfidence → 0.5');
+        if (currentConfidence < 0.45) {
+          marker.setAttribute('minConfidence', 0.45);
+          debugLog('[Marker] 感度リセット: minConfidence → 0.45');
         }
         
         lostCount = 0;  // 検出成功でリセット
@@ -313,15 +291,15 @@
         // 動的minConfidence調整（連続Lost時に感度を上げる）
         if (lostCount === 3) {
           const currentConfidence = marker.getAttribute('minConfidence');
-          if (currentConfidence >= 0.5) {
-            marker.setAttribute('minConfidence', 0.45);
-            debugLog('[Marker] 感度向上: minConfidence 0.5 → 0.45');
+          if (currentConfidence >= 0.45) {
+            marker.setAttribute('minConfidence', 0.4);
+            debugLog('[Marker] 感度向上: minConfidence 0.45 → 0.4');
           }
         } else if (lostCount === 7) {
           const currentConfidence = marker.getAttribute('minConfidence');
-          if (currentConfidence >= 0.45) {
-            marker.setAttribute('minConfidence', 0.4);
-            debugLog('[Marker] 感度さらに向上: minConfidence 0.45 → 0.4');
+          if (currentConfidence >= 0.4) {
+            marker.setAttribute('minConfidence', 0.35);
+            debugLog('[Marker] 感度さらに向上: minConfidence 0.4 → 0.35');
           }
         }
 

--- a/src/styles/bottom-sheet.css
+++ b/src/styles/bottom-sheet.css
@@ -5,36 +5,40 @@
 
 .bottom-sheet {
   position: fixed;
-  bottom: 0;
+  inset: 0;
   left: 0;
   right: 0;
   background: transparent;
   border-radius: 0;
   box-shadow: none;
-  transition: height 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: none;
   z-index: 9999; /* a-sceneより上に配置 */
-  display: flex;
-  flex-direction: column;
+  display: block;
   pointer-events: none; /* 背景はクリックを透過 */
 
   /* GPUアクセラレーション */
   transform: translateZ(0);
-  will-change: height;
+  will-change: transform;
 
-  /* デフォルトは折りたたみ状態 */
-  height: 120px;
+  --keyboard-offset: 0px;
+  --chat-input-height: 84px;
 }
 
 /* ドラッグハンドル */
 .drag-handle {
+  position: fixed;
+  left: 50%;
+  bottom: calc(var(--keyboard-offset) + var(--chat-input-height) + 10px);
   width: 40px;
   height: 4px;
-  background: transparent; /* 完全透明 */
+  background: rgba(255, 255, 255, 0.55);
   border-radius: 2px;
-  margin: 12px auto;
+  margin: 0;
   cursor: grab;
-  flex-shrink: 0;
-  display: none; /* 非表示 */
+  display: none;
+  transform: translateX(-50%);
+  pointer-events: auto;
+  z-index: 10001;
 }
 
 .drag-handle:active {
@@ -43,18 +47,86 @@
 
 /* メッセージプレビューエリア */
 .messages-preview {
-  flex: 1;
-  padding: 0 16px;
+  position: fixed;
+  left: max(12px, env(safe-area-inset-left));
+  right: max(12px, env(safe-area-inset-right));
+  bottom: calc(var(--keyboard-offset) + var(--chat-input-height) + 18px);
+  max-height: min(38dvh, 320px);
+  padding: 8px 4px;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
   gap: 8px;
+  z-index: 9999;
+  pointer-events: auto;
 
   /* スムーズなスクロール */
   -webkit-overflow-scrolling: touch;
 
   /* 初期状態は非表示 */
   display: none;
+}
+
+.bottom-sheet.state-peek .drag-handle,
+.bottom-sheet.state-expanded .drag-handle {
+  display: block;
+}
+
+.bottom-sheet.state-expanded .messages-preview {
+  max-height: min(58dvh, 520px);
+}
+
+.attachment-preview {
+  position: fixed;
+  left: max(12px, env(safe-area-inset-left));
+  right: max(12px, env(safe-area-inset-right));
+  bottom: calc(var(--keyboard-offset) + var(--chat-input-height) + 8px);
+  display: none;
+  z-index: 10000;
+  pointer-events: auto;
+}
+
+.attachment-pill,
+.attachment-error {
+  width: fit-content;
+  max-width: min(82vw, 420px);
+  margin-left: auto;
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.78);
+  backdrop-filter: blur(10px);
+  color: #333;
+  font-size: 13px;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.18);
+}
+
+.attachment-pill {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.attachment-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.attachment-remove {
+  width: 24px;
+  height: 24px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.12);
+  color: #333;
+  font-size: 14px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.attachment-error {
+  color: #9b1c1c;
 }
 
 /* スクロールバーのスタイル（Webkit） */
@@ -83,10 +155,12 @@
   gap: 8px;
   padding: 8px 12px;
   border-radius: 12px;
-  background: rgba(255, 255, 255, 0.95);
+  background: rgba(255, 255, 255, 0.78);
+  backdrop-filter: blur(10px);
   max-width: 80%;
   word-wrap: break-word;
   animation: slideIn 0.2s ease-out;
+  box-shadow: 0 4px 18px rgba(0, 0, 0, 0.18);
 }
 
 @keyframes slideIn {
@@ -102,13 +176,13 @@
 
 .message-bubble.message-user {
   align-self: flex-end;
-  background: rgba(102, 126, 234, 0.9);
+  background: rgba(102, 126, 234, 0.78);
   color: white;
 }
 
 .message-bubble.message-assistant {
   align-self: flex-start;
-  background: rgba(255, 255, 255, 0.95);
+  background: rgba(255, 255, 255, 0.78);
   color: #333;
 }
 
@@ -161,14 +235,14 @@
 /* 入力コンテナ */
 .input-container {
   position: fixed; /* fixedで配置してキーボードの影響を最小化 */
-  bottom: 0;
+  bottom: var(--keyboard-offset);
   left: 0;
   right: 0;
   margin: 0;
   padding: 12px;
   padding-bottom: max(12px, env(safe-area-inset-bottom));
-  background: rgba(255, 255, 255, 0.90); /* 可視性確保 */
-  backdrop-filter: blur(10px);
+  background: rgba(255, 255, 255, 0.70); /* ARを隠し切らない半透明レイヤー */
+  backdrop-filter: blur(14px);
   border-radius: 16px 16px 0 0;
   display: flex;
   gap: 8px;
@@ -179,12 +253,30 @@
   pointer-events: auto; /* クリック可能 */
 }
 
+.bottom-sheet-file {
+  display: none;
+}
+
+.bottom-sheet-attach {
+  width: 44px;
+  height: 44px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.82);
+  color: #333;
+  font-size: 26px;
+  line-height: 1;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
 .bottom-sheet-input {
   flex: 1;
+  min-width: 0;
   padding: 12px 16px;
   border: none;
   border-radius: 24px;
-  background: rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.82);
   font-size: 16px;
   outline: none;
   transition: background 0.2s;
@@ -206,6 +298,11 @@
   cursor: pointer;
   transition: all 0.2s;
   flex-shrink: 0;
+}
+
+.bottom-sheet-attach:active,
+.attachment-remove:active {
+  transform: scale(0.96);
 }
 
 .bottom-sheet-send:hover {
@@ -236,16 +333,20 @@
 /* 横画面対応 */
 @media (orientation: landscape) and (max-height: 600px) {
   .bottom-sheet {
-    /* 横画面時は控えめに */
-    max-height: 200px;
+    --chat-input-height: 68px;
   }
 
   .messages-preview {
-    max-height: 120px;
+    max-height: min(34dvh, 160px);
   }
 
   .input-container {
     padding: 8px 16px;
+  }
+
+  .bottom-sheet-attach {
+    width: 40px;
+    height: 40px;
   }
 }
 
@@ -258,6 +359,11 @@
   .bottom-sheet-send {
     padding: 12px 16px;
     font-size: 14px;
+  }
+
+  .bottom-sheet-attach {
+    width: 40px;
+    height: 40px;
   }
 
   .message-text {
@@ -285,6 +391,18 @@
     background: rgba(30, 30, 30, 0.3);
   }
 
+  .attachment-pill,
+  .attachment-error,
+  .bottom-sheet-attach {
+    background: rgba(50, 50, 50, 0.6);
+    color: #fff;
+  }
+
+  .attachment-remove {
+    background: rgba(255, 255, 255, 0.14);
+    color: #fff;
+  }
+
   .bottom-sheet-input {
     background: rgba(50, 50, 50, 0.6);
     color: #fff;
@@ -302,7 +420,7 @@
 /* アクセシビリティ: 高コントラストモード */
 @media (prefers-contrast: high) {
   .bottom-sheet {
-    border: 2px solid #000;
+    outline: 2px solid #000;
   }
 
   .message-bubble {

--- a/src/types/chat.types.ts
+++ b/src/types/chat.types.ts
@@ -13,6 +13,17 @@ export interface ChatMessage {
   content: string;
   timestamp: Date;
   emotion?: EmotionType;
+  attachments?: ChatAttachment[];
+}
+
+/**
+ * 画像添付
+ */
+export interface ChatAttachment {
+  mimeType: string;
+  data: string;
+  name?: string;
+  size?: number;
 }
 
 /**
@@ -38,6 +49,15 @@ export interface ChatUIEvent {
 export interface MessageSendEvent {
   message: string;
   oauthToken?: string;
+  attachments?: ChatAttachment[];
+}
+
+/**
+ * メッセージ送信ペイロード
+ */
+export interface MessageSendPayload {
+  message: string;
+  attachments?: ChatAttachment[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- stabilize AR.js loading/config and keep the AR canvas from being compressed by mobile keyboard input
- upgrade Gemini SDK usage and default to gemini-3.1-flash-lite-preview
- add image attachment support for text-only, image-only, and text+image chat payloads

## Verification
- npm run type-check:server
- npm run type-check:client
- npm run build
- Gemini smoke test: text-only, image-only, text+image