### PR TITLE
Fix camera feed layer on mobile AR

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -130,17 +130,20 @@
     body > video,
     video {
       object-fit: cover !important;
-      z-index: -2 !important;
+      z-index: 0 !important;
       transform: none !important;
+      background: transparent !important;
     }
     #ar-scene {
       display: block !important;
       overflow: hidden !important;
-      z-index: 0;
+      background: transparent !important;
+      z-index: 1;
     }
     /* A-Frame Stats（パフォーマンス監視） */
     .a-canvas {
-      z-index: 0;
+      background: transparent !important;
+      z-index: 1;
     }
     .rs-base {
       position: fixed !important;
@@ -166,6 +169,7 @@
   <a-scene
     embedded
     arjs="sourceType: webcam; trackingMethod: best; detectionMode: mono; patternRatio: 0.80; labelingMode: black_region; maxDetectionRate: 60; imageSmoothingEnabled: true; debugUIEnabled: false;"
+    renderer="alpha: true; antialias: true; precision: mediump;"
     vr-mode-ui="enabled: false"
     id="ar-scene"
   >
@@ -242,7 +246,21 @@
       document.querySelectorAll('body > video, video').forEach((video) => {
         video.style.objectFit = 'cover';
         video.style.transform = 'none';
+        video.style.zIndex = '0';
+        video.style.background = 'transparent';
       });
+
+      const arScene = document.querySelector('#ar-scene');
+      if (arScene) {
+        arScene.style.zIndex = '1';
+        arScene.style.background = 'transparent';
+      }
+
+      const canvas = document.querySelector('.a-canvas');
+      if (canvas) {
+        canvas.style.zIndex = '1';
+        canvas.style.background = 'transparent';
+      }
 
       if (scene && scene.resize) {
         scene.resize();


### PR DESCRIPTION
## Summary
- keep the AR.js camera video above the body background instead of behind it
- make the A-Frame renderer/canvas transparent so the camera feed is visible under AR content
- preserve full-viewport video/canvas synchronization while using explicit layer order: video=0, AR scene/canvas=1, UI above

## Root Cause
The previous viewport fix placed AR.js generated video at z-index -2. On iOS Safari that fixed-position video can render behind the body background, so the camera starts but the page shows only black plus UI.

## Verification
- npm run type-check:client
- npm run build:client
- npm run build
- local HTTP check for /src/index.html