### PR TITLE
[codex] Promote AR camera layer fix

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -113,9 +113,20 @@
     #orientation-warning button:hover {
       opacity: 0.8;
     }
+    #ar-scene {
+      background: transparent !important;
+      overflow: visible !important;
+      z-index: 1;
+    }
+    #arjs-video,
+    body > video {
+      z-index: 0 !important;
+      background: transparent !important;
+    }
     /* A-Frame Stats（パフォーマンス監視） */
     .a-canvas {
-      z-index: 0;
+      background: transparent !important;
+      z-index: 1 !important;
     }
     .rs-base {
       position: fixed !important;
@@ -140,7 +151,8 @@
 
   <a-scene
     embedded
-    arjs="sourceType: webcam; sourceWidth: 1280; sourceHeight: 960; displayWidth: 1280; displayHeight: 960; trackingMethod: best; detectionMode: mono; patternRatio: 0.80; labelingMode: black_region; maxDetectionRate: 60; imageSmoothingEnabled: true; debugUIEnabled: false;"
+    arjs="sourceType: webcam; sourceWidth: 1280; sourceHeight: 960; displayWidth: 1280; displayHeight: 960; trackingMethod: best; detectionMode: mono; patternRatio: 0.80; labelingMode: black_region; maxDetectionRate: 60; debugUIEnabled: false;"
+    renderer="alpha: true; antialias: true; logarithmicDepthBuffer: true; precision: medium;"
     vr-mode-ui="enabled: false"
     id="ar-scene"
   >
@@ -194,6 +206,107 @@
     };
     // エラーログは常に出力
     const errorLog = (...args) => console.error(...args);
+    const statusEl = document.querySelector('#status');
+    let cameraErrorMessage = '';
+    let cameraReadyWaitId = 0;
+
+    // AR.jsはvideoだけを中央クロップするため、canvasにも同じCSS寸法を同期する。
+    // これでカメラ映像、マーカー座標、VRM描画の画面上の基準を一致させる。
+    function syncARLayers() {
+      const video = document.querySelector('#arjs-video');
+      const canvas = document.querySelector('.a-canvas');
+      const arScene = document.querySelector('#ar-scene');
+
+      if (video) {
+        video.style.zIndex = '0';
+        video.style.background = 'transparent';
+      }
+
+      if (canvas) {
+        canvas.style.zIndex = '1';
+        canvas.style.background = 'transparent';
+
+        if (video) {
+          ['position', 'top', 'left', 'width', 'height', 'marginLeft', 'marginTop'].forEach((property) => {
+            if (video.style[property]) {
+              canvas.style[property] = video.style[property];
+            }
+          });
+        }
+      }
+
+      if (arScene) {
+        arScene.style.zIndex = '1';
+        arScene.style.background = 'transparent';
+        arScene.style.overflow = 'visible';
+      }
+    }
+
+    function getCameraVideo() {
+      return document.querySelector('#arjs-video');
+    }
+
+    function updateCameraStatus() {
+      if (cameraErrorMessage) {
+        statusEl.textContent = cameraErrorMessage;
+        return false;
+      }
+
+      const video = getCameraVideo();
+
+      if (!video) {
+        statusEl.textContent = '📷 カメラ起動中...';
+        return false;
+      }
+
+      syncARLayers();
+
+      const hasFrame = video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA
+        && video.videoWidth > 0
+        && video.videoHeight > 0;
+
+      statusEl.textContent = hasFrame ? '✨ 準備完了！' : '📷 カメラ映像を取得中...';
+      return hasFrame;
+    }
+
+    function waitForCameraReady(timeoutMs = 8000) {
+      const waitId = ++cameraReadyWaitId;
+      const startedAt = performance.now();
+
+      const tick = () => {
+        if (waitId !== cameraReadyWaitId || cameraErrorMessage) return;
+        if (updateCameraStatus()) return;
+
+        if (performance.now() - startedAt >= timeoutMs) {
+          statusEl.textContent = '📷 カメラ映像を取得できません。権限と再読み込みを確認してください';
+          errorLog('[Camera] video element is not producing frames within timeout');
+          return;
+        }
+
+        window.setTimeout(tick, 250);
+      };
+
+      tick();
+    }
+
+    window.addEventListener('arjs-video-loaded', () => {
+      syncARLayers();
+      waitForCameraReady();
+    });
+    window.addEventListener('camera-init', () => {
+      cameraErrorMessage = '';
+      statusEl.textContent = '📷 カメラ起動中...';
+      window.setTimeout(syncARLayers, 0);
+    });
+    window.addEventListener('camera-error', (event) => {
+      cameraReadyWaitId++;
+      cameraErrorMessage = '📷 カメラへのアクセスを許可してください';
+      statusEl.textContent = cameraErrorMessage;
+      errorLog('[Camera] camera-error', event.error || event);
+    });
+    window.addEventListener('resize', () => window.setTimeout(syncARLayers, 0));
+    window.visualViewport?.addEventListener('resize', () => window.setTimeout(syncARLayers, 0));
+    window.visualViewport?.addEventListener('scroll', () => window.setTimeout(syncARLayers, 0));
 
     // デバッグモード通知とStats有効化
     if (DEBUG_MODE) {
@@ -244,7 +357,7 @@
         
         lostCount = 0;  // 検出成功でリセット
         orientationWarningShown = false;  // 次回のために警告フラグリセット
-        document.querySelector('#status').textContent = '✅ マーカー検出！';
+        statusEl.textContent = '✅ マーカー検出！';
         info.classList.add('hidden');
 
         // マーカーの詳細情報をログ出力（デバッグ用）
@@ -281,7 +394,7 @@
       marker.addEventListener('markerLost', () => {
         lostCount++;
         debugLog(`[Marker] 検出ロスト (${lostCount}/${maxLostThreshold})`);
-        document.querySelector('#status').textContent = '⏳ マーカーが見えません';
+        statusEl.textContent = '⏳ マーカーが見えません';
         info.classList.remove('hidden');
 
         // 動的minConfidence調整（連続Lost時に感度を上げる）
@@ -350,7 +463,8 @@
         }, 8000);
       }
 
-      document.querySelector('#status').textContent = '✨ 準備完了！';
+      updateCameraStatus();
+      waitForCameraReady();
 
       // ボトムシートUIとチャットコントローラーを初期化
       // Vercel環境用：環境に応じてAPI URLを自動切り替え
@@ -368,7 +482,7 @@
       // VRMロードエラーハンドリング
       if (avatarEl) {
         avatarEl.addEventListener('vrm-load-error', () => {
-          document.querySelector('#status').textContent = '❌ アバターのロードに失敗しました';
+          statusEl.textContent = '❌ アバターのロードに失敗しました';
         });
       }
     });
@@ -376,7 +490,7 @@
     // カメラアクセスエラーハンドリング
     window.addEventListener('error', (e) => {
       if (e.message && e.message.includes('camera')) {
-        document.querySelector('#status').textContent = '📷 カメラへのアクセスを許可してください';
+        statusEl.textContent = '📷 カメラへのアクセスを許可してください';
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- Promotes the AR camera layer synchronization fix from `dev` to `main`.
- Restores camera visibility by keeping AR.js video, A-Frame canvas, and transparent renderer layers aligned.
- Keeps chat overlay behavior unchanged and preserves image/text payload support.

## Validation
- `npm run type-check`
- `npm run build`
- Headless Chrome fake-camera smoke confirmed a live camera frame and nonblack screenshot ratio `1.0`.
- In-app browser permission-denied scenario shows camera permission guidance instead of a false ready state.
- Mocked chat payload checks covered text-only, image-only, text+image, and empty-send blocking.