### PR TITLE
[codex] Restore avatar alignment and neutral motion

### DIFF
--- a/src/components/vrm-animation-controller.js
+++ b/src/components/vrm-animation-controller.js
@@ -65,7 +65,7 @@ AFRAME.registerComponent('vrm-animation-controller', {
     // 注：この実装により、異なる命名規則のVRMAファイルも使用可能
     // 実証済み: Mixamo (mixamorig:*), VRM標準 (J_Bip_C_*), カスタム (l_*/r_*)
     this.emotionToAnimation = {
-      'neutral': './assets/animations/idle_loop.vrma',  // 常時動くアイドルループ
+      'neutral': './assets/animations/neutral.vrma',    // 常時動くダンス寄りのモーション
       'happy': './assets/animations/happy.vrma',        // 新しいモーション
       'angry': './assets/animations/angry.vrma',        // 新しいモーション
       'sad': './assets/animations/sad.vrma',            // 新しいモーション
@@ -248,6 +248,14 @@ AFRAME.registerComponent('vrm-animation-controller', {
     }
 
     console.log(`${this.LOG_PREFIX} 🎭 感情切り替え: ${emotion}`);
+
+    // マーカー検出イベントが揺れても、常時モーションを先頭に戻さない。
+    if (emotion === this.idleEmotion && this.currentAction === action && action.isRunning()) {
+      if (this.vrm) {
+        this.setVRMExpression(emotion);
+      }
+      return;
+    }
 
     // === 現在のアニメーションのフェードアウト ===
     if (this.currentAction && this.currentAction !== action) {

--- a/src/index.html
+++ b/src/index.html
@@ -180,7 +180,7 @@
         id="avatar"
         vrm-loader="src: ./assets/models/avatar.vrm"
         vrm-animation-controller
-        position="0.55 0 -0.2"
+        position="0 0 0"
         rotation="0 0 0"
         scale="0.65 0.65 0.65"
       ></a-entity>


### PR DESCRIPTION
## Summary
- Restore the avatar marker transform to marker origin (`position="0 0 0"`) so the previous `0.55` local-x offset no longer pushes the character away from the marker on real devices.
- Restore the default neutral motion from `idle_loop.vrma` to `neutral.vrma`, matching the earlier dance-like default motion before commit `1fd5607` changed it to idle loop.
- Prevent repeated `playEmotion('neutral')` calls from resetting the neutral motion to frame 0 when marker detection jitters.

## Root cause
Commit `2fe93e8` added `position="0.55 0 -0.2"` to compensate for a fake-camera desktop scenario, but on the real AR marker orientation that local X offset moved the avatar far left. Separately, commit `1fd5607` changed neutral from `neutral.vrma` to `idle_loop.vrma`, which explains the observed idle-loop behavior.

## Validation
- Confirmed history: older index.html used `position="0 0 0"`; `1fd5607` changed neutral motion to `idle_loop.vrma`.
- `npm run type-check`
- `npm run build`
- `git diff --check`
- Fake-camera AR.js scenario: marker visible, VRM loaded, 7 VRMA actions loaded, `neutralPath=./assets/animations/neutral.vrma`, avatar position `{x:0,y:0,z:0}`, scale `{x:0.65,y:0.65,z:0.65}`, render triangles `55279`.
- Verified repeated neutral playback no longer resets action time (`4 -> 4`).