### PR TITLE
[codex] Promote avatar alignment and neutral motion fix

### DIFF
--- a/src/components/vrm-animation-controller.js
+++ b/src/components/vrm-animation-controller.js
@@ -65,7 +65,7 @@ AFRAME.registerComponent('vrm-animation-controller', {
     // 注：この実装により、異なる命名規則のVRMAファイルも使用可能
     // 実証済み: Mixamo (mixamorig:*), VRM標準 (J_Bip_C_*), カスタム (l_*/r_*)
     this.emotionToAnimation = {
-      'neutral': './assets/animations/idle_loop.vrma',  // 常時動くアイドルループ
+      'neutral': './assets/animations/neutral.vrma',    // 常時動くダンス寄りのモーション
       'happy': './assets/animations/happy.vrma',        // 新しいモーション
       'angry': './assets/animations/angry.vrma',        // 新しいモーション
       'sad': './assets/animations/sad.vrma',            // 新しいモーション
@@ -248,6 +248,14 @@ AFRAME.registerComponent('vrm-animation-controller', {
     }
 
     console.log(`${this.LOG_PREFIX} 🎭 感情切り替え: ${emotion}`);
+
+    // マーカー検出イベントが揺れても、常時モーションを先頭に戻さない。
+    if (emotion === this.idleEmotion && this.currentAction === action && action.isRunning()) {
+      if (this.vrm) {
+        this.setVRMExpression(emotion);
+      }
+      return;
+    }
 
     // === 現在のアニメーションのフェードアウト ===
     if (this.currentAction && this.currentAction !== action) {

--- a/src/index.html
+++ b/src/index.html
@@ -180,7 +180,7 @@
         id="avatar"
         vrm-loader="src: ./assets/models/avatar.vrm"
         vrm-animation-controller
-        position="0.55 0 -0.2"
+        position="0 0 0"
         rotation="0 0 0"
         scale="0.65 0.65 0.65"
       ></a-entity>


### PR DESCRIPTION
## Summary
- Promote the dev fix for real-device avatar alignment and neutral motion to main.
- Includes PR #27: restores marker-origin positioning, switches neutral back to `neutral.vrma`, and avoids resetting neutral motion on repeated marker events.

## Validation
- PR #27 checks passed: Vercel Preview Comments, Vercel, claude-review.
- Local validation before dev merge: `npm run type-check`, `npm run build`, `git diff --check`.
- Fake-camera AR.js scenario confirmed marker visibility, VRM load, 7 VRMA actions, neutral path `./assets/animations/neutral.vrma`, avatar position `{x:0,y:0,z:0}`, scale `{x:0.65,y:0.65,z:0.65}`, and render triangles `55279`.