### PR TITLE
Fix mobile keyboard overlay without resizing AR

### DIFF
--- a/src/components/BottomSheet.ts
+++ b/src/components/BottomSheet.ts
@@ -27,6 +27,11 @@ export class BottomSheet {
   private currentY: number = 0;
   private messages: ChatMessage[] = [];
   private pendingAttachment: ChatAttachment | null = null;
+  private keyboardOverlayActive: boolean = false;
+  private lockedScrollY: number = 0;
+  private stableViewportWidth: number = window.innerWidth;
+  private stableViewportHeight: number = window.innerHeight;
+  private blurReleaseTimer: number | null = null;
 
   private config: BottomSheetConfig = {
     collapsedHeight: 120,
@@ -123,7 +128,11 @@ export class BottomSheet {
       }
     });
 
+    this.inputElement.addEventListener('touchstart', this.activateKeyboardOverlayFromPointer, { passive: true });
+    this.inputElement.addEventListener('mousedown', this.activateKeyboardOverlayFromPointer);
+
     this.inputElement.addEventListener('focus', () => {
+      this.activateKeyboardOverlay();
       if (this.state === 'collapsed' && this.messages.length > 0) {
         this.peek();
       }
@@ -131,7 +140,13 @@ export class BottomSheet {
     });
 
     this.inputElement.addEventListener('blur', () => {
-      window.setTimeout(() => this.syncViewportMetrics(), 120);
+      if (this.blurReleaseTimer) {
+        window.clearTimeout(this.blurReleaseTimer);
+      }
+      this.blurReleaseTimer = window.setTimeout(() => {
+        this.deactivateKeyboardOverlay();
+        this.syncViewportMetrics();
+      }, 180);
     });
 
     window.visualViewport?.addEventListener('resize', this.syncViewportMetrics);
@@ -146,17 +161,100 @@ export class BottomSheet {
     if (!this.container) return;
 
     const viewport = window.visualViewport;
+    const layoutHeight = document.documentElement.clientHeight || window.innerHeight;
     const keyboardOffset = viewport
-      ? Math.max(0, window.innerHeight - viewport.height - viewport.offsetTop)
+      ? Math.max(0, layoutHeight - viewport.height - viewport.offsetTop)
       : 0;
 
     this.container.style.setProperty('--keyboard-offset', `${keyboardOffset}px`);
+    document.documentElement.style.setProperty('--keyboard-offset', `${keyboardOffset}px`);
 
     if (this.inputContainer) {
       const inputHeight = this.inputContainer.getBoundingClientRect().height;
       this.container.style.setProperty('--chat-input-height', `${Math.ceil(inputHeight)}px`);
     }
+
+    if (!this.keyboardOverlayActive && keyboardOffset === 0) {
+      this.captureStableViewport();
+    } else if (this.keyboardOverlayActive) {
+      this.restoreLockedScroll();
+    }
   };
+
+  /**
+   * キーボード表示前のAR表示サイズを保存する。
+   * iOS/Chromeは入力フォーカス後にvisualViewportを縮めるため、その前の値をAR背景の固定基準にする。
+   */
+  private captureStableViewport(): void {
+    const viewport = window.visualViewport;
+    const layoutWidth = document.documentElement.clientWidth || window.innerWidth;
+    const layoutHeight = document.documentElement.clientHeight || window.innerHeight;
+
+    this.stableViewportWidth = Math.round(Math.max(layoutWidth, viewport?.width || 0));
+    this.stableViewportHeight = Math.round(Math.max(layoutHeight, viewport?.height || 0));
+
+    document.documentElement.style.setProperty('--ar-layout-width', `${this.stableViewportWidth}px`);
+    document.documentElement.style.setProperty('--ar-layout-height', `${this.stableViewportHeight}px`);
+  }
+
+  private prepareKeyboardOverlay = (): void => {
+    if (this.blurReleaseTimer) {
+      window.clearTimeout(this.blurReleaseTimer);
+      this.blurReleaseTimer = null;
+    }
+
+    this.lockedScrollY = window.scrollY || document.documentElement.scrollTop || 0;
+    this.captureStableViewport();
+  };
+
+  private activateKeyboardOverlayFromPointer = (): void => {
+    this.activateKeyboardOverlay();
+    window.setTimeout(() => {
+      if (document.activeElement !== this.inputElement) {
+        this.deactivateKeyboardOverlay();
+      }
+    }, 500);
+  };
+
+  /**
+   * 入力中はチャット欄だけを半透明オーバーレイとして持ち上げ、AR/video/canvasの基準画面は固定する。
+   */
+  private activateKeyboardOverlay(): void {
+    if (this.keyboardOverlayActive) return;
+
+    this.keyboardOverlayActive = true;
+    this.prepareKeyboardOverlay();
+
+    document.documentElement.classList.add('keyboard-overlay-active');
+    document.body.classList.add('keyboard-overlay-active');
+    document.body.style.setProperty('--locked-scroll-y', `${this.lockedScrollY}px`);
+
+    window.dispatchEvent(new CustomEvent('ar-keyboard-overlay-change', { detail: { active: true } }));
+    this.restoreLockedScroll();
+  }
+
+  private deactivateKeyboardOverlay(): void {
+    if (!this.keyboardOverlayActive) return;
+
+    this.keyboardOverlayActive = false;
+    document.documentElement.classList.remove('keyboard-overlay-active');
+    document.body.classList.remove('keyboard-overlay-active');
+    document.body.style.removeProperty('--locked-scroll-y');
+    document.documentElement.style.setProperty('--keyboard-offset', '0px');
+    this.container?.style.setProperty('--keyboard-offset', '0px');
+
+    window.dispatchEvent(new CustomEvent('ar-keyboard-overlay-change', { detail: { active: false } }));
+    window.scrollTo(0, this.lockedScrollY);
+  }
+
+  private restoreLockedScroll(): void {
+    if (!this.keyboardOverlayActive) return;
+
+    window.requestAnimationFrame(() => {
+      if (!this.keyboardOverlayActive) return;
+      window.scrollTo(0, this.lockedScrollY);
+    });
+  }
 
   /**
    * 状態ごとのCSSクラスを更新

--- a/src/index.html
+++ b/src/index.html
@@ -116,8 +116,8 @@
     #ar-scene {
       position: fixed !important;
       inset: 0 !important;
-      width: 100vw !important;
-      height: 100dvh !important;
+      width: var(--ar-layout-width, 100vw) !important;
+      height: var(--ar-layout-height, 100vh) !important;
       margin: 0 !important;
       background: transparent !important;
       overflow: hidden !important;
@@ -216,43 +216,83 @@
     const statusEl = document.querySelector('#status');
     let cameraErrorMessage = '';
     let cameraReadyWaitId = 0;
+    let lastStableARVideoRect = null;
+
+    function cloneRect(rect) {
+      return {
+        top: rect.top,
+        left: rect.left,
+        width: rect.width,
+        height: rect.height
+      };
+    }
+
+    function isKeyboardOverlayActive() {
+      return document.documentElement.classList.contains('keyboard-overlay-active')
+        || document.body.classList.contains('keyboard-overlay-active');
+    }
+
+    function applyFixedLayerRect(element, rect) {
+      if (!element || !rect || rect.width <= 0 || rect.height <= 0) return;
+
+      element.style.position = 'fixed';
+      element.style.top = `${rect.top}px`;
+      element.style.left = `${rect.left}px`;
+      element.style.width = `${rect.width}px`;
+      element.style.height = `${rect.height}px`;
+      element.style.maxWidth = 'none';
+      element.style.maxHeight = 'none';
+      element.style.margin = '0';
+      element.style.transform = 'none';
+    }
 
     // AR.jsはvideoを端末比率に合わせて中央クロップするため、canvasを実測video矩形へ同期する。
     // CSS文字列だけのコピーでは親要素オフセットが残り、iOS縦画面でアバターだけ画面外へずれる。
+    // 入力中はvisualViewportが縮むので、最後に正常だったAR矩形を保持して背景を押し上げない。
     function syncARLayers() {
       const video = document.querySelector('#arjs-video');
       const canvas = document.querySelector('.a-canvas');
       const arScene = document.querySelector('#ar-scene');
+      const keyboardActive = isKeyboardOverlayActive();
+      let targetRect = lastStableARVideoRect;
 
       if (video) {
         video.style.zIndex = '0';
         video.style.background = 'transparent';
+        video.style.objectFit = 'cover';
+
+        const videoRect = video.getBoundingClientRect();
+        if (videoRect.width > 0 && videoRect.height > 0 && !keyboardActive) {
+          lastStableARVideoRect = cloneRect(videoRect);
+          targetRect = lastStableARVideoRect;
+        }
+
+        if (keyboardActive && lastStableARVideoRect) {
+          targetRect = lastStableARVideoRect;
+        } else if (videoRect.width > 0 && videoRect.height > 0) {
+          targetRect = cloneRect(videoRect);
+        }
+
+        if (targetRect && keyboardActive) {
+          applyFixedLayerRect(video, targetRect);
+        }
       }
 
       if (canvas) {
         canvas.style.position = 'fixed';
         canvas.style.zIndex = '1';
         canvas.style.background = 'transparent';
-        canvas.style.margin = '0';
-        canvas.style.transform = 'none';
 
-        if (video) {
-          const videoRect = video.getBoundingClientRect();
-
-          if (videoRect.width > 0 && videoRect.height > 0) {
-            canvas.style.top = `${videoRect.top}px`;
-            canvas.style.left = `${videoRect.left}px`;
-            canvas.style.width = `${videoRect.width}px`;
-            canvas.style.height = `${videoRect.height}px`;
-          }
+        if (targetRect) {
+          applyFixedLayerRect(canvas, targetRect);
         }
       }
 
       if (arScene) {
         arScene.style.position = 'fixed';
         arScene.style.inset = '0';
-        arScene.style.width = '100vw';
-        arScene.style.height = '100dvh';
+        arScene.style.width = 'var(--ar-layout-width, 100vw)';
+        arScene.style.height = 'var(--ar-layout-height, 100vh)';
         arScene.style.margin = '0';
         arScene.style.transform = 'none';
         arScene.style.zIndex = '1';
@@ -332,6 +372,11 @@
     window.addEventListener('resize', () => window.setTimeout(syncARLayers, 0));
     window.visualViewport?.addEventListener('resize', () => window.setTimeout(syncARLayers, 0));
     window.visualViewport?.addEventListener('scroll', () => window.setTimeout(syncARLayers, 0));
+    window.addEventListener('ar-keyboard-overlay-change', () => {
+      syncARLayers();
+      window.requestAnimationFrame(syncARLayers);
+      window.setTimeout(syncARLayers, 250);
+    });
 
     // デバッグモード通知とStats有効化
     if (DEBUG_MODE) {

--- a/src/styles/bottom-sheet.css
+++ b/src/styles/bottom-sheet.css
@@ -3,6 +3,22 @@
  * AR表示領域を最大化しながら、快適なチャット操作を提供
  */
 
+html.keyboard-overlay-active,
+body.keyboard-overlay-active {
+  overflow: hidden !important;
+  overscroll-behavior: none !important;
+  touch-action: manipulation;
+}
+
+body.keyboard-overlay-active {
+  position: fixed !important;
+  top: calc(-1 * var(--locked-scroll-y, 0px)) !important;
+  left: 0 !important;
+  right: 0 !important;
+  width: 100% !important;
+  height: var(--ar-layout-height, 100vh) !important;
+}
+
 .bottom-sheet {
   position: fixed;
   inset: 0;
@@ -235,7 +251,7 @@
 /* 入力コンテナ */
 .input-container {
   position: fixed; /* fixedで配置してキーボードの影響を最小化 */
-  bottom: var(--keyboard-offset);
+  bottom: 0;
   left: 0;
   right: 0;
   margin: 0;
@@ -251,6 +267,8 @@
   box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.1);
   z-index: 10000; /* 最前面に配置 */
   pointer-events: auto; /* クリック可能 */
+  transform: translate3d(0, calc(-1 * var(--keyboard-offset)), 0);
+  will-change: transform;
 }
 
 .bottom-sheet-file {


### PR DESCRIPTION
## Summary
- Freeze the document scroll and AR viewport while the chat input is focused.
- Keep the last stable AR.js video/canvas rect during keyboard display so the camera/VRM layer is not compressed upward.
- Move only the semi-transparent chat input overlay above the keyboard using transform instead of resizing the AR scene.

## Verification
- npm run type-check
- npm run build
- git diff --check

Note: Desktop Chrome cannot open the iOS/Android software keyboard directly, so the implementation targets the VisualViewport resize/scroll path used by Safari and Chrome on mobile devices.
