### PR TITLE
[codex] Preserve chat emotion motions and enlarge avatar

### DIFF
--- a/src/components/vrm-animation-controller.js
+++ b/src/components/vrm-animation-controller.js
@@ -54,6 +54,7 @@ AFRAME.registerComponent('vrm-animation-controller', {
     this.mixer = null;              // Three.js AnimationMixer
     this.actions = {};              // 感情別のAnimationActionマップ
     this.currentAction = null;      // 現在再生中のアクション
+    this.currentEmotion = null;     // 現在再生中の感情
     this.vrm = null;               // VRMインスタンス（外部から注入）
     this.vrmAnimations = {};       // ロード済みVRMAnimationマップ
     
@@ -84,6 +85,7 @@ AFRAME.registerComponent('vrm-animation-controller', {
     // === グローバルAPIの提供 ===
     // 外部（ChatControllerなど）からアニメーションを制御可能に
     window.playEmotion = (emotion) => this.playEmotion(emotion);
+    window.ensureIdleEmotion = () => this.ensureIdleEmotion();
   },
 
   /**
@@ -238,7 +240,35 @@ AFRAME.registerComponent('vrm-animation-controller', {
    * フェードイン/フェードアウトにより滑らかな遷移を実現。
    * メモリリーク防止のため、イベントリスナーを適切にクリーンアップ。
    */
+  normalizeEmotion(emotion) {
+    if (!emotion || typeof emotion !== 'string') {
+      return this.idleEmotion;
+    }
+
+    const normalized = emotion.trim().toLowerCase();
+    return this.emotionToAnimation[normalized] ? normalized : this.idleEmotion;
+  },
+
+  /**
+   * ARマーカー再検出時に、会話モーションをneutralで上書きしないためのidle保証。
+   */
+  ensureIdleEmotion() {
+    if (
+      this.currentEmotion
+      && this.currentEmotion !== this.idleEmotion
+      && this.currentAction
+      && this.currentAction.isRunning()
+    ) {
+      return;
+    }
+
+    if (!this.currentAction || !this.currentAction.isRunning()) {
+      this.playEmotion(this.idleEmotion);
+    }
+  },
+
   playEmotion(emotion) {
+    emotion = this.normalizeEmotion(emotion);
     const action = this.actions[emotion];
 
     if (!action) {
@@ -277,6 +307,7 @@ AFRAME.registerComponent('vrm-animation-controller', {
     action.timeScale = 1;
     action.reset().fadeIn(this.FADE_DURATION).play();
     this.currentAction = action;
+    this.currentEmotion = emotion;
 
     // === neutral以外: 終了後にneutralへ自動復帰 ===
     if (emotion !== this.idleEmotion) {
@@ -314,6 +345,7 @@ AFRAME.registerComponent('vrm-animation-controller', {
         // リスナーの削除（一度だけ実行）
         this.mixer.removeEventListener('finished', this.finishedListener);
         this.finishedListener = null;
+        this.currentEmotion = this.idleEmotion;
         
         // neutralアニメーションの再生
         this.playEmotion(this.idleEmotion);

--- a/src/index.html
+++ b/src/index.html
@@ -211,7 +211,7 @@
         vrm-animation-controller
         position="0 0 0"
         rotation="0 0 0"
-        scale="0.65 0.65 0.65"
+        scale="0.78 0.78 0.78"
       ></a-entity>
     </a-marker>
   </a-scene>
@@ -538,8 +538,8 @@
         if (markerVisible) {
           statusEl.textContent = '✅ マーカー検出！';
           info.classList.add('hidden');
-          if (window.playEmotion) {
-            window.playEmotion('neutral');
+          if (window.ensureIdleEmotion) {
+            window.ensureIdleEmotion();
           }
         }
       }
@@ -621,8 +621,8 @@
           vrmLoaded = true;
         }
 
-        if (avatarReady && window.playEmotion) {
-          window.playEmotion('neutral');
+        if (avatarReady && window.ensureIdleEmotion) {
+          window.ensureIdleEmotion();
         }
       });
 


### PR DESCRIPTION
## What changed
- Added `ensureIdleEmotion()` so AR marker reacquisition only starts idle when no conversation animation is currently running.
- Kept `window.playEmotion(data.emotion)` for chat responses, but prevented markerFound/avatar-ready paths from overwriting non-neutral motions with neutral.
- Normalized incoming emotion names before lookup.
- Increased avatar scale from `0.65` to `0.78` for better mobile visibility.

## Root cause
The chat pipeline did call emotion-specific animations, but marker detection paths also called `playEmotion('neutral')`. On a live AR camera, marker reacquisition can happen around the same time as the chat response, making it look like only `VRMA_01.vrma` was ever playing.

## Validation
- `git diff --check`
- `npm run type-check`
- `npm run build`
- Local fake-camera runtime check: after `playEmotion('happy')`, calling `ensureIdleEmotion()` keeps `currentEmotion === 'happy'` and action running.
- Runtime scale check confirmed avatar scale is `0.78`.
